### PR TITLE
Reactive var `combine` and `filter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/reactive-var/__tests__/combine.test.ts
+++ b/src/reactive-var/__tests__/combine.test.ts
@@ -1,0 +1,50 @@
+import combine from '../combine';
+import reactiveVar from '../reactive-var';
+
+describe('combine', () => {
+  it('should combine reactive variables', () => {
+    const combined = combine({
+      x: reactiveVar(1),
+      y: reactiveVar(2),
+    });
+
+    expect(combined()).toEqual({
+      x: 1,
+      y: 2,
+    });
+  });
+
+  it('should update combined variable whenever child is updated', () => {
+    const x = reactiveVar(1);
+    const y = reactiveVar(2);
+
+    const combined = combine({
+      x,
+      y,
+    });
+
+    x(4);
+
+    expect(combined()).toEqual({
+      x: 4,
+      y: 2,
+    });
+  });
+
+  it('should ignore set calls', () => {
+    const combined = combine({
+      x: reactiveVar(1),
+      y: reactiveVar(2),
+    });
+
+    combined({
+      x: 10,
+      y: -1,
+    });
+
+    expect(combined()).toEqual({
+      x: 1,
+      y: 2,
+    });
+  });
+});

--- a/src/reactive-var/__tests__/combine.test.ts
+++ b/src/reactive-var/__tests__/combine.test.ts
@@ -31,6 +31,25 @@ describe('combine', () => {
     });
   });
 
+  it('should call listener on change of any child', () => {
+    const x = reactiveVar(1);
+    const y = reactiveVar(2);
+    const combined = combine({
+      x,
+      y,
+    });
+
+    const listener = jest.fn();
+    combined.onChange(listener);
+
+    x(4);
+
+    expect(listener).toHaveBeenCalledWith({
+      x: 4,
+      y: 2,
+    });
+  });
+
   it('should ignore set calls', () => {
     const combined = combine({
       x: reactiveVar(1),

--- a/src/reactive-var/__tests__/filter.test.ts
+++ b/src/reactive-var/__tests__/filter.test.ts
@@ -1,0 +1,38 @@
+import filter from '../filter';
+import reactiveVar from '../reactive-var';
+
+describe('filter', () => {
+  it('should create filtered variable', () => {
+    const x = reactiveVar(2);
+
+    const even = filter(x, (value) => value % 2 === 0);
+
+    expect(even()).toBe(2);
+  });
+
+  it('should update filtered variable', () => {
+    const x = reactiveVar(2);
+    const even = filter(x, (value) => value % 2 === 0);
+
+    x(4);
+
+    expect(even()).toBe(4);
+  });
+
+  it('should filter updates', () => {
+    const x = reactiveVar(2);
+    const even = filter(x, (value) => value % 2 === 0);
+
+    x(3);
+
+    expect(even()).toBe(2);
+  });
+
+  it('returns undefined if initial value is not accepted by predicate', () => {
+    const x = reactiveVar(1);
+
+    const even = filter(x, (value) => value % 2 === 0);
+
+    expect(even()).toBe(undefined);
+  });
+});

--- a/src/reactive-var/__tests__/filter.test.ts
+++ b/src/reactive-var/__tests__/filter.test.ts
@@ -35,4 +35,15 @@ describe('filter', () => {
 
     expect(even()).toBe(undefined);
   });
+
+  it('should call listener on update', () => {
+    const x = reactiveVar(2);
+    const even = filter(x, (value) => value % 2 === 0);
+    const listener = jest.fn();
+    even.onChange(listener);
+
+    x(4);
+
+    expect(listener).toHaveBeenCalledWith(4);
+  });
 });

--- a/src/reactive-var/__tests__/reactive-var.test.ts
+++ b/src/reactive-var/__tests__/reactive-var.test.ts
@@ -43,7 +43,7 @@ describe('reactive var', () => {
   it('should use given equality fn', () => {
     const reactive = reactiveVar(
       { a: 1 },
-      (a, b) => JSON.stringify(a) === JSON.stringify(b),
+      (a, b) => JSON.stringify(a) === JSON.stringify(b)
     );
     const listener = jest.fn();
     reactive.onChange(listener);
@@ -66,5 +66,14 @@ describe('reactive var', () => {
     expect(y()).toEqual(4);
     expect(listener).toHaveBeenCalledWith(4);
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not set to piped value', () => {
+    const x = reactiveVar(1);
+    const piped = x.pipe((v) => v * 2);
+
+    piped(10);
+
+    expect(piped()).toBe(2);
   });
 });

--- a/src/reactive-var/__tests__/utils.test.ts
+++ b/src/reactive-var/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import reactiveVar from '../reactive-var';
+import { freeze, unfreeze } from '../utils';
+
+describe('freeze', () => {
+  it('should freeze given reactive var', () => {
+    const x = reactiveVar(1);
+
+    freeze(x);
+
+    expect(x(10)).toBe(1);
+  });
+});
+
+describe('unfreeze', () => {
+  it('should unfreeze reactive var', () => {
+    const x = reactiveVar(1);
+    freeze(x);
+
+    unfreeze(x);
+
+    expect(x(10)).toBe(10);
+  });
+});

--- a/src/reactive-var/combine.ts
+++ b/src/reactive-var/combine.ts
@@ -1,0 +1,35 @@
+import reactiveVar from './reactive-var';
+import { ReactiveVar } from './reactive-var.types';
+import { freeze, setToFrozen } from './utils';
+
+/**
+ * Accepts object as map of string keys and values as reactive vars
+ * Returns reactive var as object with same keys and values according to it's reactive vars.
+ *
+ * Seting to combined variable will be ignored
+ */
+const combine = <Config extends Record<string, ReactiveVar<any>>>(
+  config: Config
+) => {
+  const initial = Object.fromEntries(
+    Object.entries(config).map(([key, $value]) => [key, $value()])
+  );
+  const $combined = reactiveVar(initial);
+
+  Object.entries(config).forEach(([key, $value]) => {
+    $value.onChange((nextValue) => {
+      setToFrozen($combined, {
+        ...$combined(),
+        [key]: nextValue,
+      });
+    });
+  });
+
+  freeze($combined);
+
+  return $combined as ReactiveVar<{
+    [K in keyof Config]: ReturnType<Config[K]>;
+  }>;
+};
+
+export default combine;

--- a/src/reactive-var/filter.ts
+++ b/src/reactive-var/filter.ts
@@ -1,0 +1,23 @@
+import reactiveVar from './reactive-var';
+import { ReactiveVar } from './reactive-var.types';
+import { freeze, setToFrozen } from './utils';
+
+const filter = <T>(
+  $value: ReactiveVar<T>,
+  predicate: (value: T) => boolean
+) => {
+  const filtered = reactiveVar(
+    predicate($value()) ? $value() : (undefined as unknown as T)
+  );
+  freeze(filtered);
+
+  $value.onChange((next) => {
+    if (predicate(next)) {
+      setToFrozen(filtered, next);
+    }
+  });
+
+  return filtered;
+};
+
+export default filter;

--- a/src/reactive-var/index.ts
+++ b/src/reactive-var/index.ts
@@ -1,1 +1,3 @@
-export { default } from './reactive-var';
+export { default as reactiveVar } from './reactive-var';
+export * from './reactive-var.types';
+export { default as combine } from './combine';

--- a/src/reactive-var/reactive-var.types.ts
+++ b/src/reactive-var/reactive-var.types.ts
@@ -1,0 +1,39 @@
+import { FROZEN, REACTIVE } from './utils';
+
+/**
+ * A function that receives a value of type T and returns void.
+ */
+export type Listener<T> = (value: T) => void;
+
+/**
+ * A function that can be called with or without an argument of type T.
+ * When called without an argument, it returns the current value of type T.
+ * When called with an argument, it sets the current value to the argument and returns it.
+ * It also has an `onChange` method that allows registering listeners for changes to the value.
+ */
+/**
+ * A function that returns and sets a reactive variable of type T.
+ * @template T The type of the reactive variable.
+ * @param {T} [next] The value to set the reactive variable to.
+ * @returns {T} The current value of the reactive variable.
+ */
+export type ReactiveVar<T> = ((next?: T) => T) & {
+  /**
+   * Registers a listener function that will be called whenever the value changes.
+   * Returns a function that can be called to remove the listener.
+   * @param {Listener<T>} listener The listener function to register.
+   * @returns {() => void} A function that can be called to remove the listener.
+   */
+  onChange: (listener: Listener<T>) => () => void;
+
+  /**
+   * Returns a new reactive variable of type R that is derived from the current reactive variable.
+   * @template R The type of the new reactive variable.
+   * @param {(value: T) => R} fn The function used to derive the new reactive variable.
+   * @returns {ReactiveVar<R>} The new reactive variable.
+   */
+  pipe: <R>(fn: (value: T) => R) => ReactiveVar<R>;
+
+  [REACTIVE]: true;
+  [FROZEN]: boolean;
+};

--- a/src/reactive-var/utils.ts
+++ b/src/reactive-var/utils.ts
@@ -1,0 +1,47 @@
+import type { ReactiveVar } from './reactive-var.types';
+
+export const FROZEN = Symbol('frozen');
+export const REACTIVE = Symbol('reactive');
+
+export const isReactive = <T>(val: unknown): val is ReactiveVar<T> =>
+  Boolean(typeof val === 'function' && (val as ReactiveVar<T>)[REACTIVE]);
+
+/**
+ * Freezes given reactive var so any set call will be ignored
+ */
+export const freeze = <T>($value: ReactiveVar<T>) => {
+  if (!isReactive($value)) {
+    throw new TypeError('Not reactive value given');
+  }
+
+  $value[FROZEN] = true;
+};
+
+/**
+ * Removes `freeze` effect
+ *
+ * @see freeze
+ */
+export const unfreeze = <T>($value: ReactiveVar<T>) => {
+  if (!isReactive($value)) {
+    throw new TypeError('Not reactive value given');
+  }
+
+  $value[FROZEN] = false;
+};
+
+/**
+ * Sets value to frozen variable
+ */
+export const setToFrozen = <T>($value: ReactiveVar<T>, next: T) => {
+  unfreeze($value);
+  $value(next);
+  freeze($value);
+};
+
+/**
+ * A predicate that receives two values of type T and returns their equality.
+ */
+export function defaultEqualityFn<T>(a: T, b: T) {
+  return a === b;
+}


### PR DESCRIPTION
Refactors reactive var.

Now piped vars will ignore set calls.

`combine` will create new reactive var from map of reactive vars (`Record<string, ReactiveVar>`).