### PR TITLE
reactive-var: filter + map (curried)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "no-param-reassign": 0,
     "no-underscore-dangle": 0,
     "no-continue": 0,
-    "no-await-in-loop": 0
+    "no-await-in-loop": 0,
+    "import/no-cycle": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # TS code snippets
 
+![example workflow](https://github.com/qkudev/ts-snippets/actions/workflows/CI.yml/badge.svg?branch=main)
+
 This repo contains snippets with classic algorithms/solutions written in TypeScript.

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,4 +18,7 @@ module.exports = {
     '<rootDir>/src/**/*.{spec,test}.{js,ts}',
     '<rootDir>/**/*.{spec,test}.{js,ts}',
   ],
+  globals: {
+    fetch: global.fetch,
+  },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,3 @@
 require('@jest/globals');
+
+global.fetch = require('jest-fetch-mock');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/reactive-var/__tests__/filter.test.ts
+++ b/src/reactive-var/__tests__/filter.test.ts
@@ -46,4 +46,14 @@ describe('filter', () => {
 
     expect(listener).toHaveBeenCalledWith(4);
   });
+
+  it('should be carried', () => {
+    const x = reactiveVar(2);
+    const filterX = filter(x);
+    const even = filterX((value) => value % 2 === 0);
+
+    x(4);
+
+    expect(even()).toBe(4);
+  });
 });

--- a/src/reactive-var/__tests__/map.test.ts
+++ b/src/reactive-var/__tests__/map.test.ts
@@ -1,0 +1,42 @@
+import map from '../map';
+import reactiveVar from '../reactive-var';
+
+describe('filter', () => {
+  it('should create doubled variable', () => {
+    const x = reactiveVar(2);
+
+    const doubled = map(x, (value) => value * 2);
+
+    expect(doubled()).toBe(4);
+  });
+
+  it('should update mapped variable', () => {
+    const x = reactiveVar(2);
+    const doubled = map(x, (value) => value * 2);
+
+    x(4);
+
+    expect(doubled()).toBe(8);
+  });
+
+  it('should call listener on update', () => {
+    const x = reactiveVar(2);
+    const doubled = map(x, (value) => value * 2);
+    const listener = jest.fn();
+    doubled.onChange(listener);
+
+    x(4);
+
+    expect(listener).toHaveBeenCalledWith(8);
+  });
+
+  it('should be carried', () => {
+    const x = reactiveVar(2);
+    const mapX = map(x);
+    const doubled = mapX((value) => value * 2);
+
+    x(4);
+
+    expect(doubled()).toBe(8);
+  });
+});

--- a/src/reactive-var/__tests__/reactive-var.test.ts
+++ b/src/reactive-var/__tests__/reactive-var.test.ts
@@ -54,9 +54,9 @@ describe('reactive var', () => {
     expect(reactive()).toEqual({ a: 1 });
   });
 
-  it('should pipe to other value', () => {
+  it('should map to other value', () => {
     const x = reactiveVar(1);
-    const y = x.pipe((v) => v * 2);
+    const y = x.map((v) => v * 2);
 
     const listener = jest.fn();
     y.onChange(listener);
@@ -70,7 +70,7 @@ describe('reactive var', () => {
 
   it('should not set to piped value', () => {
     const x = reactiveVar(1);
-    const piped = x.pipe((v) => v * 2);
+    const piped = x.map((v) => v * 2);
 
     piped(10);
 

--- a/src/reactive-var/filter.ts
+++ b/src/reactive-var/filter.ts
@@ -2,10 +2,21 @@ import reactiveVar from './reactive-var';
 import { ReactiveVar } from './reactive-var.types';
 import { freeze, setToFrozen } from './utils';
 
-const filter = <T>(
+function filter<T>(
+  $value: ReactiveVar<T>
+): (predicate: (value: T) => boolean) => ReactiveVar<T>;
+
+function filter<T>(
   $value: ReactiveVar<T>,
   predicate: (value: T) => boolean
-) => {
+): ReactiveVar<T>;
+
+function filter<T>($value: ReactiveVar<T>, predicate?: (value: T) => boolean) {
+  if (!predicate) {
+    return (curriedPredicate: (value: T) => boolean) =>
+      filter($value, curriedPredicate);
+  }
+
   const filtered = reactiveVar(
     predicate($value()) ? $value() : (undefined as unknown as T)
   );
@@ -18,6 +29,6 @@ const filter = <T>(
   });
 
   return filtered;
-};
+}
 
 export default filter;

--- a/src/reactive-var/index.ts
+++ b/src/reactive-var/index.ts
@@ -1,3 +1,5 @@
 export { default as reactiveVar } from './reactive-var';
 export * from './reactive-var.types';
 export { default as combine } from './combine';
+export { default as map } from './map';
+export { default as filter } from './filter';

--- a/src/reactive-var/map.ts
+++ b/src/reactive-var/map.ts
@@ -1,0 +1,30 @@
+import reactiveVar from './reactive-var';
+import { ReactiveVar } from './reactive-var.types';
+import { freeze, setToFrozen } from './utils';
+
+function map<T>(
+  $value: ReactiveVar<T>
+): <R>(callback: (value: T) => R) => ReactiveVar<R>;
+
+function map<T, R>(
+  $value: ReactiveVar<T>,
+  callback: (value: T) => R
+): ReactiveVar<T>;
+
+function map<T, R>($value: ReactiveVar<T>, callback?: (value: T) => R) {
+  if (!callback) {
+    return (curriedCallback: (value: T) => boolean) =>
+      map($value, curriedCallback);
+  }
+
+  const mapped = reactiveVar(callback($value()));
+  freeze(mapped);
+
+  $value.onChange((next) => {
+    setToFrozen(mapped, callback(next));
+  });
+
+  return mapped;
+}
+
+export default map;

--- a/src/reactive-var/reactive-var.ts
+++ b/src/reactive-var/reactive-var.ts
@@ -1,11 +1,7 @@
-import {
-  FROZEN,
-  REACTIVE,
-  freeze,
-  setToFrozen,
-  defaultEqualityFn,
-} from './utils';
+import { FROZEN, REACTIVE, defaultEqualityFn } from './utils';
 import { Listener, ReactiveVar } from './reactive-var.types';
+import map from './map';
+import filter from './filter';
 
 /**
  * Creates a new reactive variable with the given initial state and optional equality function.
@@ -57,16 +53,8 @@ function reactiveVar<T>(
     };
   };
 
-  self.pipe = function pipe<R>(fn: (value: T) => R) {
-    const pipedValue = reactiveVar(fn(state));
-    freeze(pipedValue);
-
-    self.onChange((value) => {
-      setToFrozen(pipedValue, fn(value));
-    });
-
-    return pipedValue;
-  };
+  self.map = map(self as ReactiveVar<T>);
+  self.filter = filter(self as ReactiveVar<T>);
 
   return self as ReactiveVar<T>;
 }

--- a/src/reactive-var/reactive-var.types.ts
+++ b/src/reactive-var/reactive-var.types.ts
@@ -32,7 +32,13 @@ export type ReactiveVar<T> = ((next?: T) => T) & {
    * @param {(value: T) => R} fn The function used to derive the new reactive variable.
    * @returns {ReactiveVar<R>} The new reactive variable.
    */
-  pipe: <R>(fn: (value: T) => R) => ReactiveVar<R>;
+  map: <R>(fn: (value: T) => R) => ReactiveVar<R>;
+
+  /**
+   * Returns a new reactive variable of the same type that is updated only when original variable
+   * is updated and given predicate returns true.
+   */
+  filter: (predicate: (value: T) => boolean) => ReactiveVar<T>;
 
   [REACTIVE]: true;
   [FROZEN]: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement
@@ -31,6 +31,7 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true
+    "noEmit": true,
+    "experimentalDecorators": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,6 +2998,13 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5389,6 +5396,14 @@ jest-environment-node@^29.6.4:
     jest-mock "^29.6.3"
     jest-util "^29.6.3"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
@@ -6496,6 +6511,13 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -6984,6 +7006,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -8196,6 +8223,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-api-utils@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
@@ -8442,6 +8474,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+unfetch@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-5.0.0.tgz#8a5b6e5779ebe4dde0049f7d7a81d4a1af99d142"
+  integrity sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -8618,6 +8655,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -8659,6 +8701,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Adds `.map` and `.filter` methods to `ReactiveVar`.

Re-exports these helpers as curried functions of `($value: ReactiveVar<T>, callback)`