### PR TITLE
Reactive: `reduce`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/reactive/__tests__/reactive.test.ts
+++ b/src/reactive/__tests__/reactive.test.ts
@@ -67,13 +67,31 @@ describe('reactive var', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it('should not set to piped value', () => {
+  it('should not set to mapped value', () => {
     const $x = reactive(1);
     const $squareX = $x.map((v) => v * 2);
 
     $squareX(10);
 
     expect($squareX()).toBe(2);
+  });
+
+  it('should create reduced reactive var', () => {
+    const $action = reactive({ type: '@@ini' });
+    const $counter = $action.reduce((counter, action) => {
+      switch (action.type) {
+        case 'inc':
+          return counter + 1;
+        default:
+          return counter;
+      }
+    }, 0);
+
+    expect($counter(0)).toBe(0);
+
+    $action({ type: 'inc' });
+
+    expect($counter()).toBe(1);
   });
 
   it('should accept callback to modify value', () => {

--- a/src/reactive/__tests__/reduce.test.ts
+++ b/src/reactive/__tests__/reduce.test.ts
@@ -1,0 +1,54 @@
+import reactive from '../reactive';
+import reduce from '../reduce';
+
+describe('reduce', () => {
+  const $action = reactive({
+    type: '@@init',
+  });
+
+  const createReducer = reduce($action);
+
+  const reducer = (counter: number, action: { type: string }) => {
+    switch (action.type) {
+      case 'inc':
+        return counter + 1;
+      default:
+        return counter;
+    }
+  };
+
+  it('should create reducer', () => {
+    const $counter = createReducer(reducer, 0);
+    $action({
+      type: 'inc',
+    });
+    $action({
+      type: 'inc',
+    });
+
+    expect($counter()).toBe(2);
+  });
+
+  it('should be curried 1', () => {
+    const $counter = reduce($action, reducer)(0);
+    $action({ type: 'inc' });
+
+    expect($counter()).toBe(1);
+  });
+
+  it('should be curried 2', () => {
+    const $counter = reduce($action)(reducer)(0);
+
+    $action({ type: 'inc' });
+
+    expect($counter()).toBe(1);
+  });
+
+  it('should be sealed', () => {
+    const $counter = reduce($action, reducer, 0);
+
+    $counter(10);
+
+    expect($counter()).toBe(0);
+  });
+});

--- a/src/reactive/index.ts
+++ b/src/reactive/index.ts
@@ -6,3 +6,4 @@ export { default as filter } from './filter';
 export { default as onChange } from './on-change';
 export { default as join } from './join';
 export { isReactive } from './utils';
+export { default as reduce } from './reduce';

--- a/src/reactive/reactive.ts
+++ b/src/reactive/reactive.ts
@@ -5,6 +5,7 @@ import filter from './filter';
 import { bus } from './bus';
 import onChange from './on-change';
 import { createVar, getValue } from './root';
+import reduce from './reduce';
 
 /**
  * Creates a new reactive variable with the given initial state and optional equality function.
@@ -47,6 +48,7 @@ function reactive<T>(
     onChange: onChange(self as Reactive<T>),
     map: map(self as Reactive<T>),
     filter: filter(self as Reactive<T>),
+    reduce: reduce(self as Reactive<T>),
   });
 
   return self as Reactive<T>;

--- a/src/reactive/reduce.ts
+++ b/src/reactive/reduce.ts
@@ -1,0 +1,72 @@
+import reactive from './reactive';
+import { Reactive, Reducer } from './types';
+import { seal, unseal } from './utils';
+
+/**
+ * Accepts reactive var, reducer and initial state and creates new reactive var
+ * that derives it's next state by given callback, next value of given reactive var
+ * and it's own previous state.
+ *
+ * @example
+ * const $action = reactive({ type: '@@init' });
+ * const $counter = reduce($action, (counter, action) => {
+ *   switch (action.type) {
+ *    case 'increment': return counter + 1;
+ *    default: return counter;
+ *   }
+ * }, 0);
+ *
+ * $counter()                 // 0
+ * $action({ type: 'inc' });
+ * $counter();                // 1
+ */
+function reduce<El>($element: Reactive<El>): {
+  <S>(reducer: Reducer<S, El>): (initialState: S) => Reactive<S>;
+  <S>(reducer: Reducer<S, El>, initialState: S): Reactive<S>;
+};
+
+function reduce<El, S>(
+  $element: Reactive<El>,
+  reducer: Reducer<S, El>
+): (initialState: S) => Reactive<S>;
+
+function reduce<El, S>(
+  $element: Reactive<El>,
+  reducer: Reducer<S, El>,
+  initialState: S
+): Reactive<S>;
+
+function reduce<El, S>(
+  ...args:
+    | [Reactive<El>]
+    | [Reactive<El>, Reducer<S, El>]
+    | [Reactive<El>, Reducer<S, El>, S]
+): any {
+  const [$element] = args;
+  if (args.length === 1) {
+    return (
+      ...curriedArgs: readonly [Reducer<S, El>] | readonly [Reducer<S, El>, S]
+      // eslint-disable-next-line prefer-spread
+    ) => reduce.apply(null, [$element, ...curriedArgs] as any);
+  }
+  if (args.length === 2) {
+    const [, reducer] = args;
+
+    return (initialState: S): Reactive<S> =>
+      reduce($element, reducer, initialState);
+  }
+
+  const [, reducer, initialState] = args;
+  const $reduced = reactive(initialState);
+  seal($reduced);
+
+  $element.onChange((el) => {
+    unseal($reduced);
+    $reduced((state) => reducer(state, el));
+    seal($reduced);
+  });
+
+  return $reduced;
+}
+
+export default reduce;

--- a/src/reactive/types.ts
+++ b/src/reactive/types.ts
@@ -58,6 +58,29 @@ export type Reactive<Type> = ((
    */
   filter: (predicate: Predicate<Type>) => Reactive<Type>;
 
+  /**
+   * Accepts reducer and initial state and creates new reactive var
+   * that derives it's next state by given callback, next value of original reactive var
+   * and it's own previous state.
+   *
+   * @example
+   * const $action = reactive({ type: '@@init' });
+   * const $counter = $action.reduce((counter, action) => {
+   *   switch (action.type) {
+   *    case 'increment': return counter + 1;
+   *    default: return counter;
+   *   }
+   * }, 0);
+   *
+   * $counter()                 // 0
+   * $action({ type: 'inc' });
+   * $counter();                // 1
+   */
+  reduce: {
+    <S>(reducer: Reducer<S, Type>): (initialState: S) => Reactive<S>;
+    <S>(reducer: Reducer<S, Type>, initialState: S): Reactive<S>;
+  };
+
   [REACTIVE]: true;
   [ID]: number;
 };
@@ -108,3 +131,5 @@ export type VarsArrayValues<Vars extends VarsArray> = ExtractReturnType<Vars>;
 export type Combiner<InputVars extends VarsArray, Result> = (
   ...resultFuncArgs: VarsArrayValues<InputVars>
 ) => Result;
+
+export type Reducer<Acc, Element> = (accumulator: Acc, element: Element) => Acc;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,3 @@
+type TSFixMe = any;
+
+type Nullable<T> = T | null;


### PR DESCRIPTION
# Reactive: `reduce`

Adds `reduce` method:
Accepts reactive var, reducer and initial state and creates new reactive var
that derives it's next state by given callback, next value of given reactive var
and it's own previous state.

Example:
```
const $action = reactive({ type: '@@init' });
const $counter = reduce($action, (counter, action) => {
  switch (action.type) {
    case 'increment': return counter + 1;
    default: return counter;
  }
}, 0);

$counter()                 // 0
$action({ type: 'inc' });
$counter();                // 1
```