### PR TITLE
LIFO cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/lifo-cache/__tests__/lifo-cache.test.ts
+++ b/src/lifo-cache/__tests__/lifo-cache.test.ts
@@ -1,0 +1,76 @@
+import LIFOCache from '../lifo-cache';
+
+describe('FIFOCache', () => {
+  let cache = new LIFOCache(3);
+
+  beforeEach(() => {
+    cache = new LIFOCache(3);
+  });
+
+  it('should be defined', () => {
+    expect(cache).toBeDefined();
+  });
+
+  it('should set and get key', () => {
+    cache.set('a', 1);
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.size).toBe(1);
+  });
+
+  it('should set max capacity keys', () => {
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    for (const [key, value] of [
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]) {
+      expect(cache.get(key)).toBe(value);
+      expect(cache.has(key)).toBe(Boolean(value));
+    }
+
+    expect(cache.size).toBe(3);
+  });
+
+  it('should exceed capacity correctly', () => {
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    cache.set('d', 4);
+
+    for (const [key, value] of [
+      ['a', 1],
+      ['b', 2],
+      ['c', undefined],
+      ['d', 4],
+    ] as const) {
+      expect(cache.get(key)).toBe(value);
+      expect(cache.has(key)).toBe(Boolean(value));
+    }
+
+    expect(cache.size).toBe(3);
+  });
+
+  it('should delete by key', () => {
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    cache.delete('b');
+    cache.set('d', 4);
+
+    for (const [key, value] of [
+      ['a', 1],
+      ['b', undefined],
+      ['c', 3],
+      ['d', 4],
+    ] as const) {
+      expect(cache.get(key)).toBe(value);
+    }
+
+    expect(cache.size).toBe(3);
+  });
+});

--- a/src/lifo-cache/index.ts
+++ b/src/lifo-cache/index.ts
@@ -1,0 +1,1 @@
+export { default } from './lifo-cache';

--- a/src/lifo-cache/lifo-cache.ts
+++ b/src/lifo-cache/lifo-cache.ts
@@ -1,0 +1,88 @@
+type Key = string | number | Symbol;
+
+class LinkedListNode<T, K extends Key = Key> {
+  constructor(
+    public readonly key: K,
+    public readonly value: T,
+    public next: Nullable<LinkedListNode<T, K>> = null,
+    public prev: Nullable<LinkedListNode<T, K>> = null
+  ) {}
+}
+
+/**
+ * Cache with limited capacity.
+ * Acts like stack, e.g. least-in value will be deleted first
+ * if size is exceeding capacity. No matter how many
+ * times the value is used.
+ */
+class LIFOCache<T, K extends Key = Key> {
+  private head: Nullable<LinkedListNode<T, K>> = null;
+
+  public size = 0;
+
+  private mapping: Map<K, LinkedListNode<T, K>> = new Map();
+
+  public constructor(public readonly capacity: number) {}
+
+  /**
+   * Sets value by key.
+   */
+  public set(key: K, value: T) {
+    if (this.size >= this.capacity) {
+      this.deleteFromHead();
+    }
+
+    this.insertToHead(key, value);
+  }
+
+  /**
+   * Gets value by key.
+   * `undefined` if no value.
+   */
+  public get(key: K): T | undefined {
+    return this.mapping.get(key)?.value;
+  }
+
+  /**
+   * Deletes key from cache.
+   * Cache's current size is decreased by 1.
+   */
+  public delete(key: K) {
+    if (!this.mapping.has(key)) {
+      return;
+    }
+
+    const node = this.mapping.get(key)!;
+    this.mapping.delete(key);
+    node.prev = node.next;
+    this.size--;
+  }
+
+  /**
+   * Returns true if cache has key.
+   */
+  public has(key: K) {
+    return this.mapping.has(key);
+  }
+
+  private insertToHead(key: K, value: T) {
+    this.head = new LinkedListNode(key, value, this.head);
+    this.size++;
+    this.mapping.set(key, this.head);
+
+    return this.head;
+  }
+
+  private deleteFromHead() {
+    if (!this.head) {
+      return;
+    }
+
+    const toRemove = this.head;
+    this.mapping.delete(toRemove.key);
+    this.head = this.head.next;
+    this.size--;
+  }
+}
+
+export default LIFOCache;


### PR DESCRIPTION
# LIFO Cache

Cache with limited capacity.
Acts like stack, e.g. least-in value will be deleted first if size is exceeding capacity. 
No matter how many times the value is used.

Example

```
const cache = new LIFOCache(3);
cache.set('a', 1);
cache.set('b', 2);
cache.set('c', 3);
cache.set('d', 4);

console.log(cache.get('a'))   // 1
console.log(cache.get('b'))   // 2
console.log(cache.get('c'))   // undefined
console.log(cache.get('d'))   // 4
```