### PR TITLE
Extract params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/extract-params/__tests__/extract-params.test.ts
+++ b/src/extract-params/__tests__/extract-params.test.ts
@@ -1,0 +1,54 @@
+import extractParams from '../extract-params';
+
+describe('pathParams', () => {
+  it('should extract 1 param', () => {
+    const path = '/user/1';
+    const params = extractParams('/user/:userId', path);
+
+    expect(params).toEqual({ userId: '1' });
+  });
+
+  it('should extract 2 params', () => {
+    const pattern = '/user/:user_id/followers/:user_id_1';
+    const path = '/user/1/followers/10';
+
+    const params = extractParams(pattern, path);
+
+    expect(params).toEqual({
+      user_id: '1',
+      user_id_1: '10',
+    });
+  });
+
+  it('should handle param as path', () => {
+    const pattern = ':userId';
+    const path = '1';
+
+    const params = extractParams(pattern, path);
+
+    expect(params).toEqual({
+      userId: '1',
+    });
+  });
+
+  it('should handle pattern with param on start', () => {
+    const pattern = '/:userId/products/:productId';
+    const path = '/1/products/10';
+
+    const params = extractParams(pattern, path);
+
+    expect(params).toEqual({
+      userId: '1',
+      productId: '10',
+    });
+  });
+
+  it('should not extract wrong pattern params', () => {
+    const pattern = '/user/as:user/followers';
+    const path = '/user/asown/followers';
+
+    const params = extractParams(pattern, path);
+
+    expect(params).toEqual({});
+  });
+});

--- a/src/extract-params/extract-params.ts
+++ b/src/extract-params/extract-params.ts
@@ -1,0 +1,32 @@
+/**
+ * Extracts params from path by given pattern
+ *
+ * @example
+ * const params = extractParams('/user/:userId', '/user/1')
+ * console.log(params)    // { userId: '1' }
+ */
+function extractParams(pattern: string, path: string): Record<string, string> {
+  const patternParts = pattern.split('/');
+  const pathParts = path.split('/');
+  const params: Record<string, string> = {};
+
+  if (patternParts.length !== pathParts.length) {
+    return {};
+  }
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const patternPart = patternParts[i];
+    const pathPart = pathParts[i];
+
+    if (patternPart.startsWith(':')) {
+      const paramName = patternPart.slice(1);
+      params[paramName] = pathPart;
+    } else if (patternPart !== pathPart) {
+      return {};
+    }
+  }
+
+  return params;
+}
+
+export default extractParams;

--- a/src/extract-params/index.ts
+++ b/src/extract-params/index.ts
@@ -1,0 +1,1 @@
+export { default } from './path-params';


### PR DESCRIPTION
# `extractParams(pattern: string, path: string): Record<string, string>`

Adds function `extractParams` that extracts params from path with given pattern.

Example:
```
const params = extractParams('/user/:userId', '/user/1');
console.log(params);    // { userId: '1' }
```