### PR TITLE
Idle queue 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/heap/__tests__/heap.test.ts
+++ b/src/heap/__tests__/heap.test.ts
@@ -54,4 +54,16 @@ describe('Heap', () => {
     top = minHeap.pop();
     expect(top).toEqual(8);
   });
+
+  it('should clear state', () => {
+    const maxHeap = new Heap<number>((a, b) => b - a);
+    maxHeap.push(1);
+    maxHeap.push(2);
+
+    maxHeap.clear();
+    maxHeap.push(10);
+
+    expect(maxHeap.size).toBe(1);
+    expect(maxHeap.peek()).toBe(10);
+  });
 });

--- a/src/heap/heap.ts
+++ b/src/heap/heap.ts
@@ -89,6 +89,14 @@ class Heap<T> {
   public peek = (): T | undefined => this.state[1];
 
   /**
+   * Drops current queue state
+   */
+  public clear() {
+    this.state = [null as any];
+    this.realSize = 0;
+  }
+
+  /**
    * Returns the number of elements in the heap.
    */
   public get size(): number {

--- a/src/idle-queue/__tests__/idle-queue.test.ts
+++ b/src/idle-queue/__tests__/idle-queue.test.ts
@@ -63,4 +63,19 @@ describe('IdleQueue', () => {
 
     expect(result).toBe(42);
   });
+
+  it('should prioritize tasks', async () => {
+    let result = 0;
+
+    await Promise.all([
+      idle.addTask(() => {
+        result *= 2;
+      }, 10),
+      idle.addTask(() => {
+        result += 10;
+      }, 0),
+    ]);
+
+    expect(result).toBe(20);
+  });
 });

--- a/src/idle-queue/idle-queue.ts
+++ b/src/idle-queue/idle-queue.ts
@@ -1,4 +1,4 @@
-import Queue from '../queue';
+import PriorityQueue from '../priority-queue';
 
 /**
  * A function with 0 arguments
@@ -9,7 +9,7 @@ type Task<R = void> = (() => R) | (() => Promise<R>);
  * Manages a queue of tasks to be executed asynchronously when the browser is idle.
  */
 class IdleQueue {
-  private queue = new Queue<Task>();
+  private queue = new PriorityQueue<Task>();
 
   private plannedTask = false;
 
@@ -20,8 +20,9 @@ class IdleQueue {
    * fulfills when the task will be completed.
    * If the task returns anything, promise will be fulfilled with
    * result of the task.
+   * Less priority number means higher priority run.
    */
-  public addTask<R = void>(task: Task<R>): Promise<R> {
+  public addTask<R = void>(task: Task<R>, priority = 0): Promise<R> {
     return new Promise<R>((resolve, reject) => {
       this.queue.push(async () => {
         try {
@@ -29,7 +30,7 @@ class IdleQueue {
         } catch (error) {
           reject(error);
         }
-      });
+      }, priority);
 
       this.requestRun();
     });
@@ -49,7 +50,7 @@ class IdleQueue {
   };
 
   private run = async () => {
-    while (!this.queue.empty) {
+    while (!this.queue.isEmpty) {
       const task = this.queue.pop()!;
       await task();
     }

--- a/src/priority-queue/__tests__/priority-queue.test.ts
+++ b/src/priority-queue/__tests__/priority-queue.test.ts
@@ -14,5 +14,8 @@ describe('PriorityQueue', () => {
 
     pq.push({ value: 'Xerox' }, 0);
     expect(pq.peek()?.value).toEqual('Xerox');
+
+    pq.push({ value: 'Zeus' }, 2);
+    expect(pq.peek()?.value).toEqual('Xerox');
   });
 });

--- a/src/priority-queue/priority-queue.ts
+++ b/src/priority-queue/priority-queue.ts
@@ -1,7 +1,10 @@
 import { Heap } from '../heap';
 
 class QElement<T = unknown> {
-  constructor(public readonly element: T, public readonly priority: number) {}
+  constructor(
+    public readonly element: T,
+    public readonly priority: number
+  ) {}
 }
 
 class PriorityQueue<T = unknown> {
@@ -18,6 +21,10 @@ class PriorityQueue<T = unknown> {
 
   public peek(): T | undefined {
     return this.heap.peek()?.element;
+  }
+
+  public clear() {
+    this.heap.clear();
   }
 
   public get isEmpty(): boolean {


### PR DESCRIPTION
# `IdleQueue` update.

Adds `priority` param to `addTask` method.

## Example

```
let result = 0;

await Promise.all([
  idle.addTask(() => {
    result *= 2;
  }, 10),
  idle.addTask(() => {
    result += 10;
  }, 0),
]);

console.log(result);    // 20
```