### PR TITLE
`promisify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/promisify/__tests__/promisify.test.ts
+++ b/src/promisify/__tests__/promisify.test.ts
@@ -1,0 +1,53 @@
+import promisify from '../promisify';
+
+type Callback<R = void> = (err: unknown, result: R) => void;
+
+describe('promisify', () => {
+  it('should promisify function with callback', async () => {
+    const f = (cb: Callback<number>) => {
+      setTimeout(() => {
+        cb(undefined, 42);
+      }, 0);
+    };
+
+    const promisified = promisify(f);
+
+    expect(await promisified()).toBe(42);
+  });
+
+  it('should promisify function with argument', async () => {
+    const f = (n: number, cb: Callback<number>) => {
+      setTimeout(() => {
+        cb(undefined, n);
+      }, 0);
+    };
+
+    const promisified = promisify(f);
+
+    expect(await promisified(1)).toBe(1);
+  });
+
+  it('should promisify function of two arguments', async () => {
+    const f = (a: number, b: number, cb: Callback<number>) => {
+      setTimeout(() => {
+        cb(undefined, a + b);
+      }, 0);
+    };
+
+    const promisified = promisify(f);
+
+    expect(await promisified(1, 2)).toBe(3);
+  });
+
+  it('should throw error', () => {
+    const f = (cb: Callback) => {
+      setTimeout(() => {
+        cb(new Error('test'));
+      }, 0);
+    };
+
+    const promisified = promisify(f);
+
+    expect(() => promisified()).rejects.toThrow('test');
+  });
+});

--- a/src/promisify/index.ts
+++ b/src/promisify/index.ts
@@ -1,0 +1,1 @@
+export { default } from './promisify';

--- a/src/promisify/promisify.ts
+++ b/src/promisify/promisify.ts
@@ -1,0 +1,27 @@
+type Head<T extends any[]> = T extends [...infer H, any] ? H : any[];
+
+type PromisifiedFunction<T extends (...args: any[]) => any> = (
+  ...args: Head<Parameters<T>>
+) => Promise<ReturnType<T>>;
+
+/**
+ * Converts a function that uses callbacks into a function that returns a promise.
+ * @param func - The function to promisify.
+ * @returns A promisified version of the function.
+ */
+function promisify<F extends (...args: any[]) => any>(
+  func: F
+): PromisifiedFunction<F> {
+  return (...args: Head<Parameters<F>>): Promise<ReturnType<F>> =>
+    new Promise((resolve, reject) => {
+      func(...args, (error: any, result: ReturnType<F>) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+}
+
+export default promisify;


### PR DESCRIPTION
# `promisify(fn)`

`promisify(fn)`: wraps callback-based function that works like async function.