### PR TITLE
`fllatten`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.11",
+  "version": "0.8.12",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/flatten/__tests__/flatten.test.ts
+++ b/src/flatten/__tests__/flatten.test.ts
@@ -1,0 +1,39 @@
+import flatten, { NestedArray } from '../flatten';
+
+describe('flatten', () => {
+  it('should return array for flatten 0', () => {
+    const array = [1, 2, 3];
+
+    const result = flatten(array, 0);
+
+    expect(result).toEqual(array);
+  });
+
+  it('should flatten array for 1 lvl', () => {
+    const array: NestedArray<number> = [1, [2, 3, [4]]];
+
+    const result = flatten(array, 1);
+
+    expect(result).toEqual([1, 2, 3, [4]]);
+  });
+
+  it('should flatten array for 2 lvl', () => {
+    const array: NestedArray<number> = [1, [2, 3, [4, [5]]]];
+
+    const result = flatten(array, 2);
+
+    expect(result).toEqual([1, 2, 3, 4, [5]]);
+  });
+
+  it('should fully flatten array', () => {
+    const array: NestedArray<number> = [1, [2, 3, [4, [5]]]];
+
+    const result = flatten(array, Number.POSITIVE_INFINITY);
+
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should throw error for negative level', () => {
+    expect(() => flatten([1], -1)).toThrow();
+  });
+});

--- a/src/flatten/flatten.ts
+++ b/src/flatten/flatten.ts
@@ -1,0 +1,32 @@
+export type NestedArray<T> = (T | NestedArray<T>)[];
+
+/**
+ * Flatten array for given levels.
+ * Fuly flatten array by default.
+ */
+const flatten = <T>(
+  array: NestedArray<T>,
+  level = Number.POSITIVE_INFINITY
+) => {
+  if (level < 0) {
+    throw new Error('Flatten level should be no less than 0');
+  }
+
+  const result: NestedArray<T> = [];
+
+  const helper = (arr: NestedArray<T>, lvl: number) => {
+    arr.forEach((val) => {
+      if (!Array.isArray(val) || !lvl) {
+        result.push(val);
+      } else {
+        helper(val, lvl - 1);
+      }
+    });
+  };
+
+  helper(array, level);
+
+  return result;
+};
+
+export default flatten;

--- a/src/flatten/flatten.ts
+++ b/src/flatten/flatten.ts
@@ -3,6 +3,12 @@ export type NestedArray<T> = (T | NestedArray<T>)[];
 /**
  * Flatten array for given levels.
  * Fuly flatten array by default.
+ *
+ * @example
+ * const arr = [1, [2, 3, [4, [5]]]];
+ *
+ * console.log(flatten(arr));    // [1, 2, 3, 4, 5]
+ * console.log(flatten(arr, 2))  // [1, 2, 3, 4, [5]]
  */
 const flatten = <T>(
   array: NestedArray<T>,


### PR DESCRIPTION
# `flatten(arr: NestedArray<Y>, lvl: number)`

Adds `flatten(arr, lvl)` method for given nested array.

## Example

```
const arr = [1, [2, 3, [4, [5]]]];
console.log(flatten(arr));    // [1, 2, 3, 4, 5]
console.log(flatten(arr, 2));  // [1, 2, 3, 4, [5]]
```