### PR TITLE
`Monitor`:  `lock()` call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.20",
+  "version": "0.8.21",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/monitor/__tests__/monitor.test.ts
+++ b/src/monitor/__tests__/monitor.test.ts
@@ -78,4 +78,70 @@ describe('Monitor', () => {
 
     expect(result).toBe(20);
   });
+
+  it('should lock', () => {
+    let result = 0;
+
+    const f1 = monitor(async () => {
+      await wait(0);
+      result += 10;
+    });
+
+    const throws = async () => {
+      await wait(1000);
+      if (result === 0) {
+        throw new Error('Lock success');
+      }
+    };
+
+    monitor.lock();
+
+    expect(() => Promise.all([f1(), throws()])).rejects.toThrow('Lock success');
+  });
+
+  it('should unlock', () => {
+    let result = 0;
+
+    const f1 = monitor(async () => {
+      await wait(0);
+      result += 10;
+
+      return result;
+    });
+
+    const throws = async () => {
+      await wait(1000);
+      if (result === 0) {
+        throw new Error('Lock success');
+      }
+    };
+
+    const unlock = monitor.lock();
+    unlock();
+
+    expect(Promise.all([f1(), throws()])).resolves.toEqual([10]);
+  });
+
+  it('should lock independently', () => {
+    let result = 0;
+
+    const f1 = monitor(async () => {
+      await wait(0);
+      result += 10;
+
+      return result;
+    });
+
+    const throws = async () => {
+      await wait(1000);
+      if (result === 0) {
+        throw new Error('Lock success');
+      }
+    };
+
+    const unlock1 = monitor.lock();
+    unlock1();
+
+    expect(() => Promise.all([f1(), throws()])).rejects.toThrow('Lock success');
+  });
 });


### PR DESCRIPTION
# `Monitor`: adds `lock()` call

Stops function calls until `Unlock` is called.
All queued calls will sleep too.

```
const f = monitor(async () => {
  // ... some stuff
})
const unlock = monitor.lock()

f()         // "sleeps" until `unlock` is called

// ...later

unlock()    // now `f` actually runs
```